### PR TITLE
Make fixture navigation panel scroll to selected component after mount

### DIFF
--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -280,6 +280,11 @@ module.exports = React.createClass({
     window.addEventListener('resize', this.onWindowResize);
 
     this._updateContentFrameOrientation();
+
+    if (this.props.component) {
+      findDOMNode(this.refs['componentName-' + this.props.component])
+                 .scrollIntoView({behavior:'smooth'});
+    }
   },
 
   componentWillReceiveProps: function(nextProps) {


### PR DESCRIPTION
## Need
```gherkin
As a user
I want the fixture panel to scroll to the currently selected component
So that I can easily locate the fixture/component I am viewing.
```
## Deliverables
- [x] On page load, the component panel is scrolled exactly to the selected fixture.

## Solution
Scroll to selected fixture's component after the main component finishes rendering.