### PR TITLE
Pin searchbar to left nav header

### DIFF
--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -188,16 +188,16 @@ module.exports = React.createClass({
             {this.renderHomeButton()}
             {isFixtureSelected ? this.renderMenu() : null}
           </div>
+          <div className={style['filter-input-container']}>
+            <input
+              ref="filterInput"
+              className={style['filter-input']}
+              placeholder="Search..."
+              onChange={this.onSearchChange}
+            />
+            <i className={style['filter-input-icon']} />
+          </div>
           <div className={style.fixtures}>
-            <div className={style['filter-input-container']}>
-              <input
-                ref="filterInput"
-                className={style['filter-input']}
-                placeholder="Search it"
-                onChange={this.onSearchChange}
-              />
-              <i className={style['filter-input-icon']} />
-            </div>
             {this.renderFixtures()}
           </div>
         </div>

--- a/packages/react-component-playground/src/components/component-playground.less
+++ b/packages/react-component-playground/src/components/component-playground.less
@@ -158,7 +158,7 @@
     .fixtures {
       .stretch();
 
-      top: @header-height;
+      top: @header-height + @fixture-line-height;
       background: @default-darken-color;
       overflow-x: hidden;
       overflow-y: auto;


### PR DESCRIPTION
If the component/fixture list has a big length, it's too time-consuming and unnecessary to scroll to the top to find the search bar.

Thus, it needs to be fixed to the top of the component list while scrolling.