### PR TITLE
Implement redux proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:cosmos": "PACKAGE=react-cosmos npm run build-babel",
     "build:dom-polyfill": "PACKAGE=react-dom-polyfill npm run build-babel",
     "build:querystring-router": "PACKAGE=react-querystring-router npm run build-babel",
+    "build:redux-proxy": "PACKAGE=react-cosmos-redux-proxy npm run build-babel",
     "build": "rm -rf ./packages/*/lib && npm run build:component-playground && npm run build:component-tree && npm run build:cosmos && npm run build:dom-polyfill && npm run build:querystring-router",
     "prepublish": "npm run bootstrap && npm run build",
     "test": "npm run lint && karma start test/karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:dom-polyfill": "PACKAGE=react-dom-polyfill npm run build-babel",
     "build:querystring-router": "PACKAGE=react-querystring-router npm run build-babel",
     "build:redux-proxy": "PACKAGE=react-cosmos-redux-proxy npm run build-babel",
-    "build": "rm -rf ./packages/*/lib && npm run build:component-playground && npm run build:component-tree && npm run build:cosmos && npm run build:dom-polyfill && npm run build:querystring-router",
+    "build": "rm -rf ./packages/*/lib && npm run build:component-playground && npm run build:component-tree && npm run build:cosmos && npm run build:dom-polyfill && npm run build:querystring-router && npm run build:redux-proxy",
     "prepublish": "npm run bootstrap && npm run build",
     "test": "npm run lint && karma start test/karma.conf.js --single-run",
     "coveralls": "cat test/coverage/*/lcov.info | node_modules/coveralls/bin/coveralls.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "install-react:15": "npm run install-react -- react@15 react-dom@15 react-addons-test-utils@15",
     "lint": "eslint --ext '.jsx,.js' ./",
     "build-babel": "babel -D packages/$PACKAGE/src -d packages/$PACKAGE/lib",
-    "build-webpack": "webpack -p --config packages/$PACKAGE/webpack.config.js",
+    "build-webpack": "webpack --config packages/$PACKAGE/webpack.config.js",
     "build:component-playground": "PACKAGE=react-component-playground npm run build-webpack",
     "build:component-tree": "PACKAGE=react-component-tree npm run build-babel",
     "build:cosmos": "PACKAGE=react-cosmos npm run build-babel",

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -43,7 +43,10 @@ module.exports = React.createClass({
     editor: React.PropTypes.bool,
     fixture: React.PropTypes.string,
     fullScreen: React.PropTypes.bool,
-    proxies: React.PropTypes.arrayOf(React.PropTypes.func),
+    proxies: React.PropTypes.arrayOf(React.PropTypes.shape({
+      component: React.PropTypes.func,
+      props: React.PropTypes.object,
+    })),
     router: React.PropTypes.object,
   },
 
@@ -225,7 +228,7 @@ module.exports = React.createClass({
 
   renderComponent() {
     return _.reduce(this.props.proxies, (accumulator, proxy) =>
-      React.createElement(proxy, _.assign({}, this.props, {
+      React.createElement(proxy.component, _.assign({}, proxy.props, {
         children: React.Children.only(accumulator),
       })), this.loadChild('preview'));
   },

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -390,10 +390,7 @@ module.exports = React.createClass({
   componentDidUpdate(prevProps, prevState) {
     if (this.previewComponent && (
         this.constructor.didFixtureChange(prevProps, this.props) ||
-        prevState.fixtureChange !== this.state.fixtureChange ||
-        // Toggling the editor re-creates the preview component from scratch,
-        // because SplitPane is added or removed from part of the dom tree
-        prevProps.editor !== this.props.editor)) {
+        prevState.fixtureChange !== this.state.fixtureChange)) {
       this.injectPreviewChildState();
     }
   },

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -225,6 +225,11 @@ module.exports = React.createClass({
 
   renderComponent() {
     return _.reduce(this.props.proxies, (accumulator, proxy) =>
+      React.createElement(proxy, _.assign({},
+        this.constructor.getSelectedFixtureContents(this.props), {
+          children: React.Children.only(accumulator),
+        }
+      )), this.loadChild('preview'));
   },
 
   renderFixtures() {

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -43,10 +43,7 @@ module.exports = React.createClass({
     editor: React.PropTypes.bool,
     fixture: React.PropTypes.string,
     fullScreen: React.PropTypes.bool,
-    proxies: React.PropTypes.arrayOf(React.PropTypes.shape({
-      component: React.PropTypes.func,
-      props: React.PropTypes.object,
-    })),
+    proxies: React.PropTypes.arrayOf(React.PropTypes.func),
     router: React.PropTypes.object,
   },
 
@@ -228,9 +225,6 @@ module.exports = React.createClass({
 
   renderComponent() {
     return _.reduce(this.props.proxies, (accumulator, proxy) =>
-      React.createElement(proxy.component, _.assign({}, proxy.props, {
-        children: React.Children.only(accumulator),
-      })), this.loadChild('preview'));
   },
 
   renderFixtures() {

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -390,7 +390,10 @@ module.exports = React.createClass({
   componentDidUpdate(prevProps, prevState) {
     if (this.previewComponent && (
         this.constructor.didFixtureChange(prevProps, this.props) ||
-        prevState.fixtureChange !== this.state.fixtureChange)) {
+        prevState.fixtureChange !== this.state.fixtureChange ||
+        // Toggling the editor re-creates the preview component from scratch,
+        // because SplitPane is added or removed from part of the dom tree
+        prevProps.editor !== this.props.editor)) {
       this.injectPreviewChildState();
     }
   },

--- a/packages/react-component-playground/src/components/component-playground.jsx
+++ b/packages/react-component-playground/src/components/component-playground.jsx
@@ -64,6 +64,7 @@ module.exports = React.createClass({
     },
 
     getSelectedFixtureContents(props) {
+      // This returns the fixture contents as it is initially defined, excluding any modifications.
       return props.components[props.component]
                   .fixtures[props.fixture];
     },
@@ -130,7 +131,6 @@ module.exports = React.createClass({
   children: {
     preview() {
       const params = {
-        component: this.constructor.getSelectedComponentClass(this.props),
         // Child should re-render whenever fixture changes
         key: this.getPreviewComponentKey(),
         ref: (previewComponent) => {
@@ -138,10 +138,7 @@ module.exports = React.createClass({
         },
       };
 
-      // Shallow apply unserializable props
-      _.assign(params, this.state.fixtureUnserializableProps);
-
-      return _.merge(params, _.omit(this.state.fixtureContents, 'state'));
+      return _.merge(params, _.omit(this.getCurrentFixtureContents(), 'state'));
     },
 
     splitPane() {
@@ -225,11 +222,9 @@ module.exports = React.createClass({
 
   renderComponent() {
     return _.reduce(this.props.proxies, (accumulator, proxy) =>
-      React.createElement(proxy, _.assign({},
-        this.constructor.getSelectedFixtureContents(this.props), {
-          children: React.Children.only(accumulator),
-        }
-      )), this.loadChild('preview'));
+      React.createElement(proxy, _.assign({}, this.getCurrentFixtureContents(), {
+        children: React.Children.only(accumulator),
+      })), this.loadChild('preview'));
   },
 
   renderFixtures() {
@@ -558,6 +553,13 @@ module.exports = React.createClass({
       orientation: contentNode.offsetHeight > contentNode.offsetWidth ?
                    'portrait' : 'landscape',
     });
+  },
+
+  getCurrentFixtureContents() {
+    // This returns the fixture contents as it currently is, including user modifications.
+    return _.assign({
+      component: this.constructor.getSelectedComponentClass(this.props),
+    }, this.state.fixtureUnserializableProps, this.state.fixtureContents);
   },
 
   getOrientationDirection() {

--- a/packages/react-component-playground/test/components/component-playground/selected-fixture/render/children.js
+++ b/packages/react-component-playground/test/components/component-playground/selected-fixture/render/children.js
@@ -44,7 +44,7 @@ describe(`ComponentPlayground (${FIXTURE}) Render Children`, () => {
         fixture.state.fixtureUnserializableProps;
 
     Object.keys(fixtureUnserializableProps).forEach((key) => {
-      expect(childParams[key]).to.equal(fixtureUnserializableProps[key]);
+      expect(childParams[key]).to.deep.equal(fixtureUnserializableProps[key]);
     });
   });
 

--- a/packages/react-component-playground/webpack.config.js
+++ b/packages/react-component-playground/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpack = require('webpack');
 
 const src = path.join(__dirname, 'src');
 const lib = path.join(__dirname, 'lib');
@@ -51,4 +53,11 @@ module.exports = {
       loader: 'style!css',
     }],
   },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      compress: true,
+      mangle: false,
+      beautify: true,
+    }),
+  ],
 };

--- a/packages/react-cosmos-redux-proxy/package.json
+++ b/packages/react-cosmos-redux-proxy/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-cosmos-redux-proxy",
+  "version": "1.0.0-beta.1",
+  "description": "A proxy to provide redux-related context to react-cosmos",
+  "repository": "https://github.com/skidding/react-cosmos/tree/master/packages/react-cosmos-redux-proxy",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "dependencies": {
+    "redux": "^3.6.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.12 <16"
+  }
+}

--- a/packages/react-cosmos-redux-proxy/package.json
+++ b/packages/react-cosmos-redux-proxy/package.json
@@ -6,12 +6,10 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "lodash": "^4.15.0",
     "redux": "^3.6.0"
   },
   "peerDependencies": {
     "react": ">=0.12 <16"
-  },
-  "devDependencies": {
-    "lodash": "^4.15.0"
   }
 }

--- a/packages/react-cosmos-redux-proxy/package.json
+++ b/packages/react-cosmos-redux-proxy/package.json
@@ -10,5 +10,8 @@
   },
   "peerDependencies": {
     "react": ">=0.12 <16"
+  },
+  "devDependencies": {
+    "lodash": "^4.15.0"
   }
 }

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -14,6 +14,10 @@ class ReduxProxy extends React.Component {
   }
 
   render() {
+    // This creates a new element identical to this.props.children.
+    // It is needed because in older versions of React context is owner-based
+    // https://gist.github.com/jimfb/0eb6e61f300a8c1b2ce7
+    // React.cloneElement is not enough either, as it doesn't reset owner in older React versions.
     const { type, props, ref } = this.props.children;
 
     return (

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -24,7 +24,7 @@ export default ({ storeKey } = { storeKey: 'reduxStore' }) => {
 
       return (
         <div>
-          {React.createElement(type, Object.assign({}, _.omit(props, storeKey), { ref }))}
+          {React.createElement(type, _.assign({}, _.omit(props, storeKey), { ref }))}
         </div>
       );
     }

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -1,41 +1,44 @@
 import React from 'react';
 import { createStore } from 'redux';
+import _ from 'lodash';
 
-class ReduxProxy extends React.Component {
-  constructor(props) {
-    super();
-    this.store = createStore((state) => state, props.store);
+export default ({ storeKey } = { storeKey: 'reduxStore' }) => {
+  class ReduxProxy extends React.Component {
+    constructor(fixture) {
+      super();
+      this.store = createStore((state) => state, fixture[storeKey]);
+    }
+
+    getChildContext() {
+      return {
+        store: this.store,
+      };
+    }
+
+    render() {
+      // This creates a new element identical to this.props.children.
+      // It is needed because in older versions of React context is owner-based
+      // https://gist.github.com/jimfb/0eb6e61f300a8c1b2ce7
+      // React.cloneElement is not enough either, as it doesn't reset owner in older React versions.
+      const { type, props, ref } = this.props.children;
+
+      return (
+        <div>
+          {React.createElement(type, Object.assign({}, _.omit(props,
+            storeKey), { ref }))}
+        </div>
+      );
+    }
   }
 
-  getChildContext() {
-    return {
-      store: this.store,
-    };
-  }
+  ReduxProxy.propTypes = {
+    children: React.PropTypes.element.isRequired,
+  };
 
-  render() {
-    // This creates a new element identical to this.props.children.
-    // It is needed because in older versions of React context is owner-based
-    // https://gist.github.com/jimfb/0eb6e61f300a8c1b2ce7
-    // React.cloneElement is not enough either, as it doesn't reset owner in older React versions.
-    const { type, props, ref } = this.props.children;
+  ReduxProxy.childContextTypes = {
+    store: React.PropTypes.object,
+  };
 
-    return (
-      <div>
-        {React.createElement(type, Object.assign({}, props, { ref }))}
-      </div>
-    );
-  }
-}
-
-ReduxProxy.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  store: React.PropTypes.object.isRequired,
+  return ReduxProxy;
 };
-
-ReduxProxy.childContextTypes = {
-  store: React.PropTypes.object,
-};
-
-export default ReduxProxy;
 

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -24,8 +24,7 @@ export default ({ storeKey } = { storeKey: 'reduxStore' }) => {
 
       return (
         <div>
-          {React.createElement(type, Object.assign({}, _.omit(props,
-            storeKey), { ref }))}
+          {React.createElement(type, Object.assign({}, _.omit(props, storeKey), { ref }))}
         </div>
       );
     }

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -30,8 +30,13 @@ export default ({ storeKey } = { storeKey: 'reduxStore' }) => {
     }
   }
 
+  ReduxProxy.defaultProps = {
+    [storeKey]: {},
+  };
+
   ReduxProxy.propTypes = {
     children: React.PropTypes.element.isRequired,
+    [storeKey]: React.PropTypes.object,
   };
 
   ReduxProxy.childContextTypes = {

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { createStore } from 'redux';
+
+class ReduxProxy extends React.Component {
+  constructor(props) {
+    super();
+    this.store = createStore((state) => state, props.store);
+  }
+
+  getChildContext() {
+    return {
+      store: this.store,
+    };
+  }
+
+  render() {
+    const { type, props, ref } = this.props.children;
+
+    return (
+      <div>
+        {React.createElement(type, Object.assign({}, props, { ref }))}
+      </div>
+    );
+  }
+}
+
+ReduxProxy.propTypes = {
+  children: React.PropTypes.element.isRequired,
+  store: React.PropTypes.object,
+};
+
+ReduxProxy.childContextTypes = {
+  store: React.PropTypes.object,
+};
+
+export default ReduxProxy;
+

--- a/packages/react-cosmos-redux-proxy/src/index.jsx
+++ b/packages/react-cosmos-redux-proxy/src/index.jsx
@@ -30,7 +30,7 @@ class ReduxProxy extends React.Component {
 
 ReduxProxy.propTypes = {
   children: React.PropTypes.element.isRequired,
-  store: React.PropTypes.object,
+  store: React.PropTypes.object.isRequired,
 };
 
 ReduxProxy.childContextTypes = {

--- a/packages/react-cosmos-redux-proxy/test/.eslintrc.js
+++ b/packages/react-cosmos-redux-proxy/test/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../test/.eslintrc.js');

--- a/packages/react-cosmos-redux-proxy/test/redux-proxy.js
+++ b/packages/react-cosmos-redux-proxy/test/redux-proxy.js
@@ -1,4 +1,4 @@
-import reduxProxy from '../lib/index.js';
+import reduxProxy from '../src/index.jsx';
 
 const FIXTURE = 'default';
 
@@ -18,13 +18,13 @@ describe('Redux Proxy', () => {
       ));
   });
 
+  it('should render its child', () => {
+    expect(component.refs.divcomponent).to.exist;
+  });
+
   it('should attach correct store to context down to component', () => {
     const expectedStore = { foo: 'bar' };
 
     expect(component.refs.divcomponent.context.store.getState()).to.deep.equal(expectedStore);
-  });
-
-  it('should render its child', () => {
-    expect(component.refs.divcomponent).to.exist;
   });
 });

--- a/packages/react-cosmos-redux-proxy/test/redux-proxy.js
+++ b/packages/react-cosmos-redux-proxy/test/redux-proxy.js
@@ -1,0 +1,30 @@
+import reduxProxy from '../lib/index.js';
+
+const FIXTURE = 'default';
+
+describe('Redux Proxy', () => {
+  const render = require('helpers/render-component');
+
+  const fixture = require(`fixtures/redux-proxy/${FIXTURE}`);
+
+  let component;
+  let $component;
+  let container;
+
+  beforeEach(() => {
+    ({ container, component, $component } = render(fixture,
+        document.createElement('div'),
+        reduxProxy()
+      ));
+  });
+
+  it('should attach correct store to context down to component', () => {
+    const expectedStore = { foo: 'bar' };
+
+    expect(component.refs.divcomponent.context.store.getState()).to.deep.equal(expectedStore);
+  });
+
+  it('should render its child', () => {
+    expect(component.refs.divcomponent).to.exist;
+  });
+});

--- a/test/fixtures/component-playground/proxies.js
+++ b/test/fixtures/component-playground/proxies.js
@@ -29,6 +29,12 @@ const MarkupProxy = React.createClass({
 });
 
 module.exports = _.merge({}, selectedFixture, {
-  proxies: [PropMutatorProxy, MarkupProxy],
+  proxies: [{
+    component: PropMutatorProxy,
+    props: {},
+  }, {
+    component: MarkupProxy,
+    props: {},
+  }],
 });
 

--- a/test/fixtures/component-playground/proxies.js
+++ b/test/fixtures/component-playground/proxies.js
@@ -29,12 +29,6 @@ const MarkupProxy = React.createClass({
 });
 
 module.exports = _.merge({}, selectedFixture, {
-  proxies: [{
-    component: PropMutatorProxy,
-    props: {},
-  }, {
-    component: MarkupProxy,
-    props: {},
-  }],
+  proxies: [PropMutatorProxy, MarkupProxy],
 });
 

--- a/test/fixtures/redux-proxy/default.js
+++ b/test/fixtures/redux-proxy/default.js
@@ -1,0 +1,19 @@
+/* eslint-disable react/prefer-stateless-function */
+// Stick to ES6 class syntax instead of stateless functions as it supports refs
+
+const React = require('react');
+
+class DivComponent extends React.Component {
+  render() {
+    return React.createElement('div');
+  }
+}
+
+DivComponent.contextTypes = {
+  store: React.PropTypes.object,
+};
+
+module.exports = {
+  children: React.createElement(DivComponent, { ref: 'divcomponent' }),
+  reduxStore: { foo: 'bar' },
+};

--- a/test/helpers/render-component.js
+++ b/test/helpers/render-component.js
@@ -5,9 +5,10 @@ import ComponentPlayground from '../../packages/react-component-playground/src';
 
 const ReactDOM = require('../../packages/react-dom-polyfill')(React);
 
-module.exports = (fixture, container = document.createElement('div')) => {
+module.exports = (fixture, container = document.createElement('div'),
+  componentType = ComponentPlayground) => {
   const component = ComponentTree.render({
-    component: ComponentPlayground,
+    component: componentType,
     snapshot: fixture,
     container,
   });


### PR DESCRIPTION
This adds a proxy which creates a Redux store using `createStore` and passes it to the children's context.

It will be published as a separate package, `react-cosmos-redux-proxy`.