### PR TITLE
Remove optional dep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,5 @@
 module.exports = {
   extends: [
     "airbnb"
-  ],
-  rules: {
-    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}]
-  }
+  ]
 };

--- a/packages/react-component-playground/package.json
+++ b/packages/react-component-playground/package.json
@@ -18,8 +18,5 @@
   },
   "peerDependencies": {
     "react": ">=0.12 <16"
-  },
-  "optionalDependencies": {
-    "react-dom": "<16"
   }
 }

--- a/packages/react-component-tree/package.json
+++ b/packages/react-component-tree/package.json
@@ -11,8 +11,5 @@
   },
   "peerDependencies": {
     "react": ">=0.12 <16"
-  },
-  "optionalDependencies": {
-    "react-dom": "<16"
   }
 }

--- a/packages/react-dom-polyfill/README.md
+++ b/packages/react-dom-polyfill/README.md
@@ -18,14 +18,11 @@ const ReactDOM = reactDOMPolyfill(React);
 ```
 
 Notes:
-- Also update your React/ReactDOM peer dependencies to make your published lib compatible with all React versions. The latter should be optional. This is a rough example:
+- Also update your React/ReactDOM peer dependencies to make your published lib compatible with all React versions. The latter should be removed (and thus optional). This is a rough example:
 
   ```json
   "peerDependencies": {
     "react": ">=0.12 <16"
-  },
-  "optionalDependencies": {
-    "react-dom": "<16"
   }
   ```
 - Even though calling `findDOMNode` on DOM element refs is not required in newer versions of React, you must always do it to account for older Reacts. This makes this polyfill somewhat *special*. E.g.

--- a/packages/react-dom-polyfill/README.md
+++ b/packages/react-dom-polyfill/README.md
@@ -18,7 +18,7 @@ const ReactDOM = reactDOMPolyfill(React);
 ```
 
 Notes:
-- Also update your React/ReactDOM peer dependencies to make your published lib compatible with all React versions. The latter should be removed (and thus optional). This is a rough example:
+- Also update your React/ReactDOM peer dependencies to make your published lib compatible with all React versions. The latter should be missing (and thus optional). This is a rough example:
 
   ```json
   "peerDependencies": {

--- a/packages/react-dom-polyfill/package.json
+++ b/packages/react-dom-polyfill/package.json
@@ -8,9 +8,6 @@
   "peerDependencies": {
     "react": ">=0.12 <16"
   },
-  "optionalDependencies": {
-    "react-dom": "<16"
-  },
   "browserify": {
     "transform": "browserify-optional"
   }

--- a/packages/react-dom-polyfill/src/index.js
+++ b/packages/react-dom-polyfill/src/index.js
@@ -4,7 +4,7 @@ module.exports = (React) => {
   if (version >= 0.14) {
     // Let bundlers (e.g. webpack) know react-dom won't always be there
     try {
-      // eslint-disable-next-line global-require
+      // eslint-disable-next-line global-require, import/no-extraneous-dependencies
       return require('react-dom');
     } catch (e) {
       return null;

--- a/packages/react-querystring-router/package.json
+++ b/packages/react-querystring-router/package.json
@@ -11,8 +11,5 @@
   },
   "peerDependencies": {
     "react": ">=0.12 <16"
-  },
-  "optionalDependencies": {
-    "react-dom": "<16"
   }
 }

--- a/scripts/prune-react-copies.js
+++ b/scripts/prune-react-copies.js
@@ -1,4 +1,5 @@
 const path = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const rimraf = require('rimraf');
 
 rimraf(path.join(__dirname, '../packages/*/node_modules/react{,-dom}'), (error) => {


### PR DESCRIPTION
After seeing weird npm install warnings I realized putting `react-dom` in `optionalDependencies` would still yell at you when using older Reacts.

Then I re-read https://docs.npmjs.com/files/package.json#optionaldependencies and it seems `optionalDependencies` is more tied to `dependencies` than `peerDependencies`, which is were `react` & `react-dom` belong, so it seems like the cleanest thing to do is to omit it altogether. If you have React >=0.14 in your project & use React Cosmos you will have ReactDOM installed as well.